### PR TITLE
urllib3 CVE-2019-11324

### DIFF
--- a/newbie/bot/requirements.txt
+++ b/newbie/bot/requirements.txt
@@ -96,7 +96,7 @@ text-unidecode==1.2
 tinydb==3.11.1
 typing-extensions==3.7.2
 tzlocal==1.5.1
-urllib3==1.23
+urllib3==1.24.2
 virtualenv==16.0.0
 websocket-client==0.53.0
 Werkzeug==0.14.1


### PR DESCRIPTION
Vulnerable versions: < 1.24.2
Patched version: 1.24.2

The urllib3 library before 1.24.2 for Python mishandles certain cases
where the desired set of CA certificates is different from the OS store
of CA certificates, which results in SSL connections succeeding in
situations where a verification failure is the correct outcome. This is
related to use of the ssl_context, ca_certs, or ca_certs_dir argument.